### PR TITLE
fix(ReadyOrNot): update DLSS vendor check pattern for March 2026 update

### DIFF
--- a/OptiPatcher/dllmain.cpp
+++ b/OptiPatcher/dllmain.cpp
@@ -571,15 +571,29 @@ static void CheckForPatch()
         _patchResult = patchAddressDLSSCheck != nullptr;
     }
 
-    // RoboCop: Unfinished Business, Ready or Not, NINJA GAIDEN 2 Black, Hell is Us (+ Demo), Brothers: A Tale of Two
+    // Ready or Not
+    else if (exeName == "readyornotsteam-win64-shipping.exe" ||
+             exeName == "readyornot-wingdk-shipping.exe")
+    {
+        std::string_view pattern("84 C0 B8 04 00 00 00 74 03 49 8B C7 8B 34 30 4C 89 A4 24 "
+                                 "? ? ? ? 4C 89 B4 24 ? ? ? ? E8 ? ? ? ? 84 C0 75");
+        auto patchAddress = (void*) scanner::GetAddress(exeModule, pattern, 36);
+        if (patchAddress != nullptr)
+        {
+            std::vector<BYTE> patch = { 0x0C, 0x01 };
+            patcher::PatchAddress(patchAddress, &patch);
+            _patchResult = true;
+        }
+    }
+
+    // RoboCop: Unfinished Business, NINJA GAIDEN 2 Black, Hell is Us (+ Demo), Brothers: A Tale of Two
     // Sons Remake, Otherskin, The Sinking City Remastered, Chernobylite 2: Exclusion Zone, Commandos: Origins,
     // MindsEye, Crisol: Theater of Idols (+ Demo), Frostpunk 2, Enotria: The Last Song, VOID/BREAKER, Celestial Empire,
     // Alien: Rogue Incursion Evolved Edition, Manor Lords, Nobody Wants to Die, Valor Mortis playtest, Fort Solis,
     // Spirit of the North 2, Tokyo Xtreme Racer/Shutokou Battle, INDUSTRIA 2 Demo, REANIMAL (+ Demo), Keeper (+WinGDK
     // PaganIdol exe), Stygian: Outer Gods, Tormented Souls 2, Assetto Corsa Rally, SpongeBob SquarePants: Titans of the
     // Tide, Echoes of the End: Enhanced Edition, Supraworld, ROMEO IS A DEAD MAN, Solasta II
-    else if (CHECK_UE(robocopunfinishedbusiness) || exeName == "readyornotsteam-win64-shipping.exe" ||
-             exeName == "readyornot-wingdk-shipping.exe" || CHECK_UE(ninjagaiden2black) || CHECK_UE(hellisus) ||
+    else if (CHECK_UE(robocopunfinishedbusiness) || CHECK_UE(ninjagaiden2black) || CHECK_UE(hellisus) ||
              CHECK_UE(brothers) || CHECK_UE(otherskin) || CHECK_UE(thesinkingcityremastered) ||
              CHECK_UE(chernobylite2) || CHECK_UE(commandos) || CHECK_UE(mindseye) || CHECK_UE(crtoiprototype) ||
              CHECK_UE(frostpunk2) || CHECK_UE(enotria) || CHECK_UE(voidbreaker) || CHECK_UE(china_builder_06) ||


### PR DESCRIPTION
## Summary

The March 12, 2026 (1.4) game update changed the code generated around the `IsNvidia()` call site used for the DLSS GPU vendor check. The previous pattern no longer matched, causing the patch to silently fail.

## Changes

- Extracted a new unique byte pattern from the updated binary
- Updated the offset from `40` to `36`
- Moved Ready or Not out of the shared UE `CHECK_UE` block into its own dedicated `else if` entry (the new pattern is specific to this game and doesn't apply to the generic UE path)

## Pattern

**Old (broken):**
```
84 C0 75 0E E8 ? ? ? ? 84 C0 B8 04 00 00 00 74 03 49 8B C7 44 39 3C 18 48 8B ? ? ? ? ? 0F 95 C3 E8 ? ? ? ? 84 C0 75
offset: 40
```

**New:**
```
84 C0 B8 04 00 00 00 74 03 49 8B C7 8B 34 30 4C 89 A4 24 ? ? ? ? 4C 89 B4 24 ? ? ? ? E8 ? ? ? ? 84 C0 75
offset: 36
```

Pattern verified as unique (1 hit) in `ReadyOrNotSteam-Win64-Shipping.exe` (148 MB, Mar 12 2026).


<img width="1945" height="1942" alt="image" src="https://github.com/user-attachments/assets/1fcbe7a1-fdef-403b-affe-7e6270ac14da" />
